### PR TITLE
resolve clippy warnings

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -136,7 +136,7 @@ pub fn load_input_file(file_name: &str, precision: u32, parser_context: &mut par
     // Parse the input file content, resulting in the symbol table being filled out.
     // Output is not needed here.
     if let Err(error) = parser::eval(parser_context, &file_content, precision) {
-        eprintln!("{}", error.to_string());
+        eprintln!("{}", error);
     }
 }
 

--- a/kalk/src/calculation_result.rs
+++ b/kalk/src/calculation_result.rs
@@ -53,7 +53,7 @@ impl CalculationResult {
         let decimal_count = if let Some(dot_index) = value.chars().position(|c| c == '.') {
             let end_index = value.chars().position(|c| c == ' ' || c == 'i').unwrap_or(value.len()) - 1;
 
-            if end_index > dot_index { end_index - dot_index } else { 0 }
+            end_index.saturating_sub(dot_index)
         } else {
             0
         };

--- a/kalk/src/errors.rs
+++ b/kalk/src/errors.rs
@@ -38,55 +38,57 @@ pub enum KalkError {
     WasStmt(crate::ast::Stmt),
 }
 
-impl ToString for KalkError {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for KalkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            KalkError::CannotIndexByImaginary => String::from("Cannot index by imaginary numbers."),
-            KalkError::CanOnlyIndexX => String::from("Indexing (getting an item with a specific index) is only possible on vectors and matrices."),
-            KalkError::Expected(description) => format!("Expected: {}", description),
-            KalkError::ExpectedDx => String::from("Expected eg. dx, to specify for which variable the operation is being done to. Example with integration: ∫(0, 1, x dx) or ∫(0, 1, x, dx). You may need to put parenthesis around the expression before dx/dy/du/etc."),
-            KalkError::ExpectedIf => String::from("Expected 'if', with a condition after it."),
-            KalkError::ExpectedReal => String::from("Expected a real value but got imaginary."),
-            KalkError::IncompatibleTypesForOperation(operation, got1, got2) => format!("Incompatible types for operation '{}': {} and {}.", operation, got1, got2),
-            KalkError::IncompatibleVectorsMatrixes => String::from("Incompatible vectors/matrixes."),
-            KalkError::IncorrectAmountOfArguments(expected, func, got) => format!(
+            KalkError::CannotIndexByImaginary => write!(f, "Cannot index by imaginary numbers."),
+            KalkError::CanOnlyIndexX => write!(f, "Indexing (getting an item with a specific index) is only possible on vectors and matrices."),
+            KalkError::Expected(description) => write!(f, "Expected: {}", description),
+            KalkError::ExpectedDx => write!(f, "Expected eg. dx, to specify for which variable the operation is being done to. Example with integration: ∫(0, 1, x dx) or ∫(0, 1, x, dx). You may need to put parenthesis around the expression before dx/dy/du/etc."),
+            KalkError::ExpectedIf => write!(f, "Expected 'if', with a condition after it."),
+            KalkError::ExpectedReal => write!(f, "Expected a real value but got imaginary."),
+            KalkError::IncompatibleTypesForOperation(operation, got1, got2) => write!(f, "Incompatible types for operation '{}': {} and {}.", operation, got1, got2),
+            KalkError::IncompatibleVectorsMatrixes => write!(f, "Incompatible vectors/matrixes."),
+            KalkError::IncorrectAmountOfArguments(expected, func, got) => write!(
+                f,
                 "Expected {} arguments for function {}, but got {}.",
                 expected, func, got
             ),
-            KalkError::IncorrectAmountOfIndexes(expected,  got) => format!(
+            KalkError::IncorrectAmountOfIndexes(expected,  got) => write!(
+                f,
                 "Expected {} indexes but got {}.",
                 expected, got
             ),
-            KalkError::ItemOfIndexDoesNotExist(indices) => format!("Item of index ⟦{}⟧ does not exist.", indices.iter().map(|x| x.to_string()).collect::<Vec<String>>().join(", ")),
-            KalkError::InconsistentColumnWidths => String::from("Inconsistent column widths. Matrix columns must be the same size."),
-            KalkError::InvalidBase => String::from("Invalid base."),
-            KalkError::InvalidComprehension(x) => format!("Invalid comprehension: {}", x),
-            KalkError::InvalidNumberLiteral(x) => format!("Invalid number literal: '{}'.", x),
-            KalkError::InvalidOperator => String::from("Invalid operator."),
-            KalkError::InvalidUnit => String::from("Invalid unit."),
-            KalkError::StackOverflow => String::from("Operation recursed too deeply."),
-            KalkError::TimedOut => String::from("Operation took too long."),
-            KalkError::VariableReferencesItself => String::from("Variable references itself."),
-            KalkError::PiecewiseConditionsAreFalse => String::from("All the conditions in the piecewise are false."),
-            KalkError::EvaluationError(msg) => format!("Evaluation error: {}", msg),
+            KalkError::ItemOfIndexDoesNotExist(indices) => write!(f, "Item of index ⟦{}⟧ does not exist.", indices.iter().map(|x| x.to_string()).collect::<Vec<String>>().join(", ")),
+            KalkError::InconsistentColumnWidths => write!(f, "Inconsistent column widths. Matrix columns must be the same size."),
+            KalkError::InvalidBase => write!(f, "Invalid base."),
+            KalkError::InvalidComprehension(x) => write!(f, "Invalid comprehension: {}", x),
+            KalkError::InvalidNumberLiteral(x) => write!(f, "Invalid number literal: '{}'.", x),
+            KalkError::InvalidOperator => write!(f, "Invalid operator."),
+            KalkError::InvalidUnit => write!(f, "Invalid unit."),
+            KalkError::StackOverflow => write!(f, "Operation recursed too deeply."),
+            KalkError::TimedOut => write!(f, "Operation took too long."),
+            KalkError::VariableReferencesItself => write!(f, "Variable references itself."),
+            KalkError::PiecewiseConditionsAreFalse => write!(f, "All the conditions in the piecewise are false."),
+            KalkError::EvaluationError(msg) => write!(f, "Evaluation error: {}", msg),
             KalkError::UnexpectedToken(got, expected) => {
                 if let Some(expected) = expected {
-                    format!("Unexpected token: '{:?}', expected '{:?}'.", got, expected)
+                    write!(f, "Unexpected token: '{:?}', expected '{:?}'.", got, expected)
                 } else {
-                    format!("Unexpected token: '{:?}'.", got)
+                    write!(f, "Unexpected token: '{:?}'.", got)
                 }
             }
             KalkError::UnexpectedType(got, expected) => {
-                format!("Unexpected type. Got {:?} but expected: {:?}.", got, expected.join(", "))
+                write!(f, "Unexpected type. Got {:?} but expected: {:?}.", got, expected.join(", "))
             }
-            KalkError::UnableToInvert(msg) => format!("Unable to invert: {}", msg),
-            KalkError::UndefinedFn(name) => format!("Undefined function: '{}'.", name),
-            KalkError::UndefinedVar(name) => format!("Undefined variable: '{}'.", name),
-            KalkError::UnableToParseExpression => String::from("Unable to parse expression."),
-            KalkError::UnableToSolveEquation => String::from("Unable to solve equation."),
-            KalkError::UnableToOverrideConstant(name) => format!("Unable to override constant: '{}'.", name),
-            KalkError::UnrecognizedBase => String::from("Unrecognized base."),
-            KalkError::Unknown | KalkError::WasStmt(_) => String::from("Unknown error."),
+            KalkError::UnableToInvert(msg) => write!(f, "Unable to invert: {}", msg),
+            KalkError::UndefinedFn(name) => write!(f, "Undefined function: '{}'.", name),
+            KalkError::UndefinedVar(name) => write!(f, "Undefined variable: '{}'.", name),
+            KalkError::UnableToParseExpression => write!(f, "Unable to parse expression."),
+            KalkError::UnableToSolveEquation => write!(f, "Unable to solve equation."),
+            KalkError::UnableToOverrideConstant(name) => write!(f, "Unable to override constant: '{}'.", name),
+            KalkError::UnrecognizedBase => write!(f, "Unrecognized base."),
+            KalkError::Unknown | KalkError::WasStmt(_) => write!(f, "Unknown error."),
         }
     }
 }

--- a/kalk/src/kalk_value/mod.rs
+++ b/kalk/src/kalk_value/mod.rs
@@ -634,11 +634,7 @@ impl KalkValue {
                 Some(&to_unit.to_string()),
             );
 
-            if let Ok(num) = result {
-                Some(num)
-            } else {
-                None
-            }
+            result.ok()
         } else {
             None
         }

--- a/kalk/src/numerical.rs
+++ b/kalk/src/numerical.rs
@@ -32,8 +32,8 @@ pub fn derive_func(
         let coefficient = if k != 0 {
             let mut first_num = 1;
             let mut last_num = 1;
-            (1..=k).for_each(|f| first_num = first_num * f);
-            (n - k + 1..=n).for_each(|f| last_num = last_num * f);
+            (1..=k).for_each(|f| first_num *= f);
+            (n - k + 1..=n).for_each(|f| last_num *= f);
 
             KalkValue::from(last_num / first_num)
         } else {
@@ -354,7 +354,7 @@ mod tests {
     use crate::symbol_table::SymbolTable;
     use crate::test_helpers::*;
 
-    fn get_context(symbol_table: &mut SymbolTable) -> interpreter::Context {
+    fn get_context(symbol_table: &mut SymbolTable) -> interpreter::Context<'_> {
         interpreter::Context::new(
             symbol_table,
             "",

--- a/kalk/src/parser.rs
+++ b/kalk/src/parser.rs
@@ -969,26 +969,6 @@ mod tests {
         );
     }
 
-    #[wasm_bindgen_test]
-    fn test_pow_unary() {
-        let tokens = vec![
-            token(Literal, "10"),
-            token(Power, ""),
-            token(Minus, ""),
-            token(Literal, "1"),
-            token(Eof, ""),
-        ];
-
-        assert_eq!(
-            parse(tokens).unwrap(),
-            Stmt::Expr(binary(
-                f64_to_float_literal(10f64),
-                Power,
-                unary(Minus, f64_to_float_literal(1f64))
-            )),
-        );
-    }
-
     #[test]
     #[wasm_bindgen_test]
     fn test_percent() {

--- a/kalk/src/prelude/with_rug.rs
+++ b/kalk/src/prelude/with_rug.rs
@@ -68,8 +68,8 @@ pub(crate) mod funcs {
         let (real, _, _) = as_number_or_return!(x);
         let (real_rhs, _, _) = as_number_or_return!(y);
 
-        let x = real.to_i32_saturating().unwrap_or(i32::MAX) as i32;
-        let y = real_rhs.to_i32_saturating().unwrap_or(i32::MAX) as i32;
+        let x = real.to_i32_saturating().unwrap_or(i32::MAX);
+        let y = real_rhs.to_i32_saturating().unwrap_or(i32::MAX);
         if y < 0 {
             Ok(KalkValue::from(x >> y.abs()))
         } else {

--- a/kalk/src/radix.rs
+++ b/kalk/src/radix.rs
@@ -8,11 +8,7 @@ pub fn parse_float_radix(value: &str, radix: u8) -> Option<KalkFloat> {
         #[cfg(not(feature = "rug"))]
         let parsed = value.parse::<f64>();
 
-        return if let Ok(result) = parsed {
-            Some(result)
-        } else {
-            None
-        };
+        return parsed.ok();
     }
 
     let mut sum = float!(0f64);

--- a/kalk/src/text_utils.rs
+++ b/kalk/src/text_utils.rs
@@ -45,11 +45,7 @@ pub fn is_subscript(c: &char) -> bool {
 }
 
 pub fn parse_subscript(chars: impl Iterator<Item = char>) -> Option<u8> {
-    if let Ok(result) = subscript_to_normal(chars).parse::<u8>() {
-        Some(result)
-    } else {
-        None
-    }
+    subscript_to_normal(chars).parse::<u8>().ok()
 }
 
 pub fn subscript_to_normal(chars: impl Iterator<Item = char>) -> String {
@@ -80,7 +76,7 @@ pub fn subscript_to_normal(chars: impl Iterator<Item = char>) -> String {
         });
     }
 
-    return regular.trim().to_string();
+    regular.trim().to_string()
 }
 
 pub fn normal_to_subscript(chars: impl Iterator<Item = char>) -> String {


### PR DESCRIPTION
Implement Display for KalkError. Resolve a hidden
lifetime that is elided in numerical.rs. The function test_pow_unary is unused. Remove it.